### PR TITLE
Fix compilation error under Windows 10.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -54,7 +54,7 @@ if localsymbol
   $defs << %q('-DRBEXT_API=__attribute__ ((visibility("default")))') <<
            %q(-DRBEXT_VISIBILITY=1)
 else
-  $defs << %q(-DRBEXT_API)
+  $defs << %q(-DRBEXT_API=)
 end
 
 create_makefile File.join(RUBY_VERSION[/\d+\.\d+/], "extlz4")


### PR DESCRIPTION
RBEXT_API needs to explicitly be set to empty.